### PR TITLE
All Polearms Implemented

### DIFF
--- a/src/components/CharacterModal.tsx
+++ b/src/components/CharacterModal.tsx
@@ -39,7 +39,7 @@ const CharacterModal = ({
     onOpenChange,
     setCharacter,
 }: CharacterModalProps) => {
-    const DEFAULT_CHARACTER = 'Furina'
+    const DEFAULT_CHARACTER = 'Hu Tao'
 
     const [rawCharacters, setRawCharacters] = useState<RawCharacter[]>([])
     const [filteredCharacters, setFilteredCharacters] = useState<RawCharacter[]>([])

--- a/src/data/characters/hu-tao.tsx
+++ b/src/data/characters/hu-tao.tsx
@@ -149,6 +149,7 @@ const talentScalings: TalentScaling = {
             attribute: ['ATK'],
             additiveBonusStat: ['Elemental Burst Additive Bonus'],
             multiplicativeBonusStat: ['Pyro DMG Bonus', 'Elemental Burst DMG Bonus'],
+            critRateBonusStat: ['Elemental Burst CRIT Rate'],
             damageType: DamageType.Pyro,
         },
         'Low HP Skill DMG': {
@@ -156,6 +157,7 @@ const talentScalings: TalentScaling = {
             attribute: ['ATK'],
             additiveBonusStat: ['Elemental Burst Additive Bonus'],
             multiplicativeBonusStat: ['Pyro DMG Bonus', 'Elemental Burst DMG Bonus'],
+            critRateBonusStat: ['Elemental Burst CRIT Rate'],
             damageType: DamageType.Pyro,
         },
         'Skill HP Regeneration': {

--- a/src/data/characters/hu-tao.tsx
+++ b/src/data/characters/hu-tao.tsx
@@ -242,7 +242,7 @@ const characterBonuses: Bonus[] = [
             }
         },
         origin: 'E',
-        priority: 3,
+        priority: 2,
     },
     {
         name: 'Sanguine Rogue',
@@ -312,7 +312,7 @@ const constellationBonuses: Bonus[] = [
         },
         minConstellation: 2,
         origin: 'C2',
-        priority: 3,
+        priority: 2,
     },
     {
         name: 'Lingering Carmine',

--- a/src/data/characters/mona.tsx
+++ b/src/data/characters/mona.tsx
@@ -204,7 +204,7 @@ const characterBonuses: Bonus[] = [
         enabled: true,
         origin: 'A4',
         minAscension: 4,
-        priority: 3,
+        priority: 2,
     },
 ]
 

--- a/src/data/characters/yelan.tsx
+++ b/src/data/characters/yelan.tsx
@@ -207,7 +207,7 @@ const characterBonuses: Bonus[] = [
         stackOptions: ['Off', '1 Same', '2 Same', '3 Same', '4 Same'],
         origin: 'A1',
         minAscension: 1,
-        priority: 3,
+        priority: 1,
     },
     {
         name: 'Adapt With Ease',
@@ -343,7 +343,7 @@ const constellationBonuses: Bonus[] = [
         stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks', '4 Stacks'],
         origin: 'C4',
         minConstellation: 4,
-        priority: 3,
+        priority: 1,
     },
     {
         name: "Dealer's Sleight",

--- a/src/data/weapons/ballad-of-the-fjords.tsx
+++ b/src/data/weapons/ballad-of-the-fjords.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Tales of the Tundra',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const elementalMasteryBonusPerStack = [120, 150, 180, 210, 240] 
+
+            const newAttributes = {
+                ...attributes,
+                'Elemental Mastery': (attributes['Elemental Mastery'] || 0) + elementalMasteryBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const BalladOfTheFjords: Weapon = {
     name: 'Ballad of the Fjords',
@@ -76,31 +93,51 @@ const BalladOfTheFjords: Weapon = {
     refinements: [
         {
             description:
-                'When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 120.',
+                <span>
+                    When there are at least <span style={{ color: '#ddd' }}>3</span> different Elemental Types in your party, 
+                    Elemental Mastery will be increased by <span style={{ color: '#ddd' }}>120</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 150.',
+                <span>
+                    When there are at least <span style={{ color: '#ddd' }}>3</span> different Elemental Types in your party, 
+                    Elemental Mastery will be increased by <span style={{ color: '#ddd' }}>150</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 180.',
+                <span>
+                    When there are at least <span style={{ color: '#ddd' }}>3</span> different Elemental Types in your party, 
+                    Elemental Mastery will be increased by <span style={{ color: '#ddd' }}>180</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 210.',
+                <span>
+                    When there are at least <span style={{ color: '#ddd' }}>3</span> different Elemental Types in your party, 
+                    Elemental Mastery will be increased by <span style={{ color: '#ddd' }}>210</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 240.',
+                <span>
+                    When there are at least <span style={{ color: '#ddd' }}>3</span> different Elemental Types in your party, 
+                    Elemental Mastery will be increased by <span style={{ color: '#ddd' }}>240</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default BalladOfTheFjords

--- a/src/data/weapons/black-tassel.tsx
+++ b/src/data/weapons/black-tassel.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Bane of the Soft',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const slimeDamageBonusPerStack = [0.4, 0.5, 0.6, 0.7, 0.8] 
+
+            const newAttributes = {
+                ...attributes,
+                'All DMG Bonus': (attributes['All DMG Bonus'] || 0) + slimeDamageBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const BlackTassel: Weapon = {
     name: 'Black Tassel',
@@ -74,27 +91,47 @@ const BlackTassel: Weapon = {
     },
     refinements: [
         {
-            description: 'Increases DMG against slimes by 40%.',
+            description: 
+            <span>
+                Increases DMG against slimes by <span style={{ color: '#ddd' }}>40%</span>.
+            </span>
+            ,
             level: 1,
         },
         {
-            description: 'Increases DMG against slimes by 50%.',
+            description: 
+            <span>
+                Increases DMG against slimes by <span style={{ color: '#ddd' }}>50%</span>.
+            </span>
+            ,
             level: 2,
         },
         {
-            description: 'Increases DMG against slimes by 60%.',
+            description: 
+            <span>
+                Increases DMG against slimes by <span style={{ color: '#ddd' }}>60%</span>.
+            </span>
+            ,
             level: 3,
         },
         {
-            description: 'Increases DMG against slimes by 70%.',
+            description: 
+            <span>
+                Increases DMG against slimes by <span style={{ color: '#ddd' }}>70%</span>.
+            </span>
+            ,
             level: 4,
         },
         {
-            description: 'Increases DMG against slimes by 80%.',
+            description: 
+            <span>
+                Increases DMG against slimes by <span style={{ color: '#ddd' }}>80%</span>.
+            </span>
+            ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default BlackTassel

--- a/src/data/weapons/blackcliff-pole.tsx
+++ b/src/data/weapons/blackcliff-pole.tsx
@@ -1,9 +1,27 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Press the Advantage',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.12, 0.15, 0.18, 0.21, 0.24] 
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) * (1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1])
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 3,
+        stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks'],
+        priority: 1
+    }
+]
 
 const BlackcliffPole: Weapon = {
     name: 'Blackcliff Pole',
@@ -76,31 +94,51 @@ const BlackcliffPole: Weapon = {
     refinements: [
         {
             description:
-                'After defeating an enemy, ATK is increased by 12% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.',
+                <span>
+                    After defeating an enemy, ATK is increased by <span style={{ color: '#ddd' }}>12%</span> for 30s. 
+                    This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'After defeating an enemy, ATK is increased by 15% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.',
+                <span>
+                    After defeating an enemy, ATK is increased by <span style={{ color: '#ddd' }}>15%</span> for 30s. 
+                    This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'After defeating an enemy, ATK is increased by 18% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.',
+                <span>
+                    After defeating an enemy, ATK is increased by <span style={{ color: '#ddd' }}>18%</span> for 30s. 
+                    This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'After defeating an enemy, ATK is increased by 21% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.',
+                <span>
+                    After defeating an enemy, ATK is increased by <span style={{ color: '#ddd' }}>21%</span> for 30s. 
+                    This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'After defeating an enemy, ATK is increased by 24% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.',
+                <span>
+                    After defeating an enemy, ATK is increased by <span style={{ color: '#ddd' }}>24%</span> for 30s. 
+                    This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default BlackcliffPole

--- a/src/data/weapons/calamity-queller.tsx
+++ b/src/data/weapons/calamity-queller.tsx
@@ -112,55 +112,50 @@ const CalamityQueller: Weapon = {
             description:
                 <span>
                     Gain <span style={{ color: '#ddd' }}>12%</span> All Elemental DMG Bonus. 
-                    Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>3.2%</span> per second. 
-                    This ATK increase has a maximum of 6 stacks. 
-                    When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+                    After using an Elemental Skill, ATK increases by <span style={{ color: '#ddd' }}>3.2%</span> per second. 
+                    Maximum of 6 stacks. When the character equipped with this weapon is not on the field, this effect is doubled.
                 </span>
                 ,
             level: 1,
         },
         {
             description:
-            <span>
-                Gain <span style={{ color: '#ddd' }}>15%</span> All Elemental DMG Bonus. 
-                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>4%</span> per second. 
-                This ATK increase has a maximum of 6 stacks. 
-                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
-            </span>
-            ,
+                <span>
+                    Gain <span style={{ color: '#ddd' }}>15%</span> All Elemental DMG Bonus. 
+                    After using an Elemental Skill, ATK increases by <span style={{ color: '#ddd' }}>4%</span> per second. 
+                    Maximum of 6 stacks. When the character equipped with this weapon is not on the field, this effect is doubled.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-            <span>
-                Gain <span style={{ color: '#ddd' }}>18%</span> All Elemental DMG Bonus. 
-                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>4.8%</span> per second. 
-                This ATK increase has a maximum of 6 stacks. 
-                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
-            </span>
-            ,
+                <span>
+                    Gain <span style={{ color: '#ddd' }}>18%</span> All Elemental DMG Bonus. 
+                    After using an Elemental Skill, ATK increases by <span style={{ color: '#ddd' }}>4.8%</span> per second. 
+                    Maximum of 6 stacks. When the character equipped with this weapon is not on the field, this effect is doubled.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-            <span>
-                Gain <span style={{ color: '#ddd' }}>21%</span> All Elemental DMG Bonus. 
-                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>5.6%</span> per second. 
-                This ATK increase has a maximum of 6 stacks. 
-                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
-            </span>
-            ,
+                <span>
+                    Gain <span style={{ color: '#ddd' }}>21%</span> All Elemental DMG Bonus. 
+                    After using an Elemental Skill, ATK increases by <span style={{ color: '#ddd' }}>5.6%</span> per second. 
+                    Maximum of 6 stacks. When the character equipped with this weapon is not on the field, this effect is doubled.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-            <span>
-                Gain <span style={{ color: '#ddd' }}>24%</span> All Elemental DMG Bonus. 
-                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>6.4%</span> per second. 
-                This ATK increase has a maximum of 6 stacks. 
-                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
-            </span>
-            ,
+                <span>
+                    Gain <span style={{ color: '#ddd' }}>24%</span> All Elemental DMG Bonus. 
+                    After using an Elemental Skill, ATK increases by <span style={{ color: '#ddd' }}>6.4%</span> per second. 
+                    Maximum of 6 stacks. When the character equipped with this weapon is not on the field, this effect is doubled.
+                </span>
+                ,
             level: 5,
         },
     ],

--- a/src/data/weapons/calamity-queller.tsx
+++ b/src/data/weapons/calamity-queller.tsx
@@ -1,9 +1,43 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Extinguishing Precept',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const elementalDamageBonus = [0.12, 0.15, 0.18, 0.21, 0.24]
+            const attackBonusPerStack = [0.032, 0.04, 0.048, 0.056, 0.064]
+
+            let attackBonus = 0
+
+            if(currentStacks <= 6) {
+                attackBonus = (attributes['ATK'] || 0) * (currentStacks * attackBonusPerStack[state.weaponRefinement - 1])
+            } else if (currentStacks > 6) {
+                attackBonus = (attributes['ATK'] || 0) * ((currentStacks - 5) * attackBonusPerStack[state.weaponRefinement - 1] * 2)
+            }
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) + attackBonus,
+                'Pyro DMG Bonus': (attributes['Pyro DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Cryo DMG Bonus': (attributes['Cryo DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Hydro DMG Bonus': (attributes['Hydro DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Electro DMG Bonus': (attributes['Electro DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Anemo DMG Bonus': (attributes['Anemo DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Geo DMG Bonus': (attributes['Geo DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1],
+                'Dendro DMG Bonus': (attributes['Dendro DMG Bonus'] || 0) + elementalDamageBonus[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 12,
+        stackOptions: ['Off', '1 Stack On-Field', '2 Stacks On-Field', '3 Stacks On-Field', '4 Stacks On-Field', '5 Stacks On-Field', '6 Stacks On-Field', '1 Stack Off-Field', '2 Stacks Off-Field', '3 Stacks Off-Field', '4 Stacks Off-Field', '5 Stacks Off-Field', '6 Stacks Off-Field'],
+        priority: 1
+    }
+]
 
 const CalamityQueller: Weapon = {
     name: 'Calamity Queller',
@@ -76,31 +110,61 @@ const CalamityQueller: Weapon = {
     refinements: [
         {
             description:
-                "Gain 12% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 3.2% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
+                <span>
+                    Gain <span style={{ color: '#ddd' }}>12%</span> All Elemental DMG Bonus. 
+                    Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>3.2%</span> per second. 
+                    This ATK increase has a maximum of 6 stacks. 
+                    When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                "Gain 15% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 4% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
+            <span>
+                Gain <span style={{ color: '#ddd' }}>15%</span> All Elemental DMG Bonus. 
+                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>4%</span> per second. 
+                This ATK increase has a maximum of 6 stacks. 
+                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                "Gain 18% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 4.8% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
+            <span>
+                Gain <span style={{ color: '#ddd' }}>18%</span> All Elemental DMG Bonus. 
+                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>4.8%</span> per second. 
+                This ATK increase has a maximum of 6 stacks. 
+                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+            </span>
+            ,
             level: 3,
         },
         {
             description:
-                "Gain 21% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 5.6% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
+            <span>
+                Gain <span style={{ color: '#ddd' }}>21%</span> All Elemental DMG Bonus. 
+                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>5.6%</span> per second. 
+                This ATK increase has a maximum of 6 stacks. 
+                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+            </span>
+            ,
             level: 4,
         },
         {
             description:
-                "Gain 24% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 6.4% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
+            <span>
+                Gain <span style={{ color: '#ddd' }}>24%</span> All Elemental DMG Bonus. 
+                Obtain Consummation for <span style={{ color: '#ddd' }}>20s</span> after using an Elemental Skill, causing ATK to increase by <span style={{ color: '#ddd' }}>6.4%</span> per second. 
+                This ATK increase has a maximum of 6 stacks. 
+                When the character equipped with this weapon is not on the field, Consummation&apos;s ATK increase is doubled.
+            </span>
+            ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default CalamityQueller

--- a/src/data/weapons/deathmatch.tsx
+++ b/src/data/weapons/deathmatch.tsx
@@ -1,9 +1,40 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Gladiator',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.16, 0.2, 0.24, 0.28, 0.32]
+            const defenceBonusPerStack = [0.16, 0.2, 0.24, 0.28, 0.32]
+            const opponentLowAttackBonusPerStack = [0.24, 0.3, 0.36, 0.42, 0.48]
+
+            let attackBonus = 0
+            let defenceBonus = 0
+
+            if (currentStacks === 1) {
+                attackBonus = attributes['ATK'] * attackBonusPerStack[state.weaponRefinement - 1]
+                defenceBonus = attributes['DEF'] * defenceBonusPerStack[state.weaponRefinement - 1]
+            } else if (currentStacks === 2) {
+                attackBonus = attributes['ATK'] * opponentLowAttackBonusPerStack[state.weaponRefinement - 1]
+            }
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) + attackBonus,
+                DEF: (attributes['DEF'] || 0) + defenceBonus
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 2,
+        stackOptions: ['Off', '>=2 Opponents', '<2 Opponents'],
+        priority: 1
+    }
+]
 
 const Deathmatch: Weapon = {
     name: 'Deathmatch',
@@ -76,31 +107,51 @@ const Deathmatch: Weapon = {
     refinements: [
         {
             description:
-                'If there are at least 2 opponents nearby, ATK is increased by 16% and DEF is increased by 16%. If there are fewer than 2 opponents nearby, ATK is increased by 24%.',
+                <span>
+                    If there are at least 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>16%</span> and DEF is increased by <span style={{ color: '#ddd' }}>16%</span>. 
+                    If there are fewer than 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>24%</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'If there are at least 2 opponents nearby, ATK is increased by 20% and DEF is increased by 20%. If there are fewer than 2 opponents nearby, ATK is increased by 30%.',
+                <span>
+                    If there are at least 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>20%</span> and DEF is increased by <span style={{ color: '#ddd' }}>20%</span>. 
+                    If there are fewer than 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>30%</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'If there are at least 2 opponents nearby, ATK is increased by 24% and DEF is increased by 24%. If there are fewer than 2 opponents nearby, ATK is increased by 36%.',
+                <span>
+                    If there are at least 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>24%</span> and DEF is increased by <span style={{ color: '#ddd' }}>24%</span>. 
+                    If there are fewer than 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>36%</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'If there are at least 2 opponents nearby, ATK is increased by 28% and DEF is increased by 28%. If there are fewer than 2 opponents nearby, ATK is increased by 42%.',
+                <span>
+                    If there are at least 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>28%</span> and DEF is increased by <span style={{ color: '#ddd' }}>28%</span>. 
+                    If there are fewer than 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>42%</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'If there are at least 2 opponents nearby, ATK is increased by 32% and DEF is increased by 32%. If there are fewer than 2 opponents nearby, ATK is increased by 48%.',
+                <span>
+                    If there are at least 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>32%</span> and DEF is increased by <span style={{ color: '#ddd' }}>32%</span>. 
+                    If there are fewer than 2 opponents nearby, ATK is increased by <span style={{ color: '#ddd' }}>48%</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default Deathmatch

--- a/src/data/weapons/dragons-bane.tsx
+++ b/src/data/weapons/dragons-bane.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Bane of Flame and Water',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const allDamageBonusPerStack = [0.20, 0.24, 0.28, 0.32, 0.36]
+
+            const newAttributes = {
+                ...attributes,
+                'All DMG Bonus': (attributes['All DMG Bonus'] || 0) + allDamageBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const DragonsBane: Weapon = {
     name: "Dragon's Bane",
@@ -76,31 +93,46 @@ const DragonsBane: Weapon = {
     refinements: [
         {
             description:
-                'Increases DMG against opponents affected by Hydro or Pyro by 20%.',
+                <span>
+                    Increases DMG against opponents affected by Hydro or Pyro by <span style={{ color: '#ddd' }}>20%</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Increases DMG against opponents affected by Hydro or Pyro by 24%.',
+                <span>
+                    Increases DMG against opponents affected by Hydro or Pyro by <span style={{ color: '#ddd' }}>24%</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'Increases DMG against opponents affected by Hydro or Pyro by 28%.',
+                <span>
+                    Increases DMG against opponents affected by Hydro or Pyro by <span style={{ color: '#ddd' }}>28%</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'Increases DMG against opponents affected by Hydro or Pyro by 32%.',
+                <span>
+                    Increases DMG against opponents affected by Hydro or Pyro by <span style={{ color: '#ddd' }}>32%</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'Increases DMG against opponents affected by Hydro or Pyro by 36%.',
+                <span>
+                    Increases DMG against opponents affected by Hydro or Pyro by <span style={{ color: '#ddd' }}>36%</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default DragonsBane

--- a/src/data/weapons/engulfing-lightning.tsx
+++ b/src/data/weapons/engulfing-lightning.tsx
@@ -1,9 +1,36 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Timeless Dream: Eternal Stove',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const energyRechargetoAttackBonus = [0.28, 0.35, 0.42, 0.49, 0.56]
+            const energyRechargetoAttackMax = [0.8, 0.9, 1.0, 1.1, 1.2]
+            const burstEnergyRechargeBonus = [0.3, 0.35, 0.4, 0.45, 0.5]
+
+            let hasBurst = 0
+
+            if(currentStacks === 2) {
+                hasBurst = burstEnergyRechargeBonus[state.weaponRefinement - 1]
+            }
+
+            const newAttributes = {
+                ...attributes,
+                ATK: attributes['ATK' || 0] * (1 + Math.min(((attributes['Energy Recharge'] || 0) - 1 + hasBurst) * energyRechargetoAttackBonus[state.weaponRefinement - 1], energyRechargetoAttackMax[state.weaponRefinement - 1])),
+                'Energy Recharge': attributes['Energy Recharge' || 0] + hasBurst
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 2,
+        stackOptions: ['Off', 'Enabled', 'Enabled + Burst'],
+        priority: 2
+    }
+]
 
 const EngulfingLightning: Weapon = {
     name: 'Engulfing Lightning',
@@ -76,31 +103,56 @@ const EngulfingLightning: Weapon = {
     refinements: [
         {
             description:
-                'ATK increased by 28% of Energy Recharge over the base 100%. You can gain a maximum bonus of 80% ATK. Gain 30% Energy Recharge for 12s after using an Elemental Burst.',
+                <span>
+                    ATK increased by <span style={{ color: '#ddd' }}>28%</span> of Energy Recharge over the base 100%. 
+                    You can gain a maximum bonus of <span style={{ color: '#ddd' }}>80%</span> ATK.
+                    Gain <span style={{ color: '#ddd' }}>30%</span> Energy Recharge for <span style={{ color: '#ddd' }}>12s</span> after using an Elemental Burst.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'ATK increased by 35% of Energy Recharge over the base 100%. You can gain a maximum bonus of 90% ATK. Gain 35% Energy Recharge for 12s after using an Elemental Burst.',
+                <span>
+                    ATK increased by <span style={{ color: '#ddd' }}>35%</span> of Energy Recharge over the base 100%. 
+                    You can gain a maximum bonus of <span style={{ color: '#ddd' }}>90%</span> ATK.
+                    Gain <span style={{ color: '#ddd' }}>35%</span> Energy Recharge for <span style={{ color: '#ddd' }}>12s</span> after using an Elemental Burst.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'ATK increased by 42% of Energy Recharge over the base 100%. You can gain a maximum bonus of 100% ATK. Gain 40% Energy Recharge for 12s after using an Elemental Burst.',
+                <span>
+                    ATK increased by <span style={{ color: '#ddd' }}>42%</span> of Energy Recharge over the base 100%. 
+                    You can gain a maximum bonus of <span style={{ color: '#ddd' }}>100%</span> ATK.
+                    Gain <span style={{ color: '#ddd' }}>40%</span> Energy Recharge for <span style={{ color: '#ddd' }}>12s</span> after using an Elemental Burst.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'ATK increased by 49% of Energy Recharge over the base 100%. You can gain a maximum bonus of 110% ATK. Gain 45% Energy Recharge for 12s after using an Elemental Burst.',
+                <span>
+                    ATK increased by <span style={{ color: '#ddd' }}>49%</span> of Energy Recharge over the base 100%. 
+                    You can gain a maximum bonus of <span style={{ color: '#ddd' }}>110%</span> ATK.
+                    Gain <span style={{ color: '#ddd' }}>45%</span> Energy Recharge for <span style={{ color: '#ddd' }}>12s</span> after using an Elemental Burst.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'ATK increased by 56% of Energy Recharge over the base 100%. You can gain a maximum bonus of 120% ATK. Gain 50% Energy Recharge for 12s after using an Elemental Burst.',
+                <span>
+                    ATK increased by <span style={{ color: '#ddd' }}>56%</span> of Energy Recharge over the base 100%. 
+                    You can gain a maximum bonus of <span style={{ color: '#ddd' }}>120%</span> ATK.
+                    Gain <span style={{ color: '#ddd' }}>50%</span> Energy Recharge for <span style={{ color: '#ddd' }}>12s</span> after using an Elemental Burst.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default EngulfingLightning

--- a/src/data/weapons/favonius-lance.tsx
+++ b/src/data/weapons/favonius-lance.tsx
@@ -1,9 +1,15 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        // LMAO
+        name: 'Windfall',
+        effect: (attributes) => {
+            return { attributes }
+        },
+    }
+]
 
 const FavoniusLance: Weapon = {
     name: 'Favonius Lance',
@@ -76,31 +82,51 @@ const FavoniusLance: Weapon = {
     refinements: [
         {
             description:
-                'CRIT Hits have a 60% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 12s.',
+                <span>
+                    CRIT Hits have a <span style={{ color: '#ddd' }}>60%</span> chance to generate a small amount of Elemental Particles, 
+                    which will regenerate <span style={{ color: '#ddd' }}>6</span> Energy for the character. Can only occur once every <span style={{ color: '#ddd' }}>12s</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'CRIT Hits have a 70% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 10.5s.',
+            <span>
+                CRIT Hits have a <span style={{ color: '#ddd' }}>70%</span> chance to generate a small amount of Elemental Particles, 
+                which will regenerate <span style={{ color: '#ddd' }}>6</span> Energy for the character. Can only occur once every <span style={{ color: '#ddd' }}>10.5s</span>.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'CRIT Hits have a 80% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 9s.',
+                <span>
+                    CRIT Hits have a <span style={{ color: '#ddd' }}>80%</span> chance to generate a small amount of Elemental Particles, 
+                    which will regenerate <span style={{ color: '#ddd' }}>6</span> Energy for the character. Can only occur once every <span style={{ color: '#ddd' }}>9s</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'CRIT Hits have a 90% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 7.5s.',
+                <span>
+                    CRIT Hits have a <span style={{ color: '#ddd' }}>90%</span> chance to generate a small amount of Elemental Particles, 
+                    which will regenerate <span style={{ color: '#ddd' }}>6</span> Energy for the character. Can only occur once every <span style={{ color: '#ddd' }}>7.5s</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'CRIT Hits have a 100% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 6s.',
+                <span>
+                    CRIT Hits have a <span style={{ color: '#ddd' }}>100%</span> chance to generate a small amount of Elemental Particles, 
+                    which will regenerate <span style={{ color: '#ddd' }}>6</span> Energy for the character. Can only occur once every <span style={{ color: '#ddd' }}>6s</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default FavoniusLance

--- a/src/data/weapons/halberd.tsx
+++ b/src/data/weapons/halberd.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Heavy',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const normalAttackAdditivePerStack = [1.6, 2.0, 2.4, 2.8, 3.2] 
+
+            const newAttributes = {
+                ...attributes,
+                'Normal Attack Additive Bonus': (attributes['Normal Attack Additive Bonus'] || 0) + (normalAttackAdditivePerStack[state.weaponRefinement - 1] * attributes['ATK'])
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 2
+    }
+]
 
 const Halberd: Weapon = {
     name: 'Halberd',
@@ -76,31 +93,46 @@ const Halberd: Weapon = {
     refinements: [
         {
             description:
-                'Normal Attacks deal an additional 160% ATK as DMG. Can only occur once every 10s.',
+                <span>
+                    Normal Attacks deal an additional <span style={{ color: '#ddd' }}>160%</span> ATK as DMG. This effect can only occur once every <span style={{ color: '#ddd' }}>10s</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Normal Attacks deal an additional 200% ATK as DMG. This effect can only occur once every 10s.',
+                <span>
+                    Normal Attacks deal an additional <span style={{ color: '#ddd' }}>200%</span> ATK as DMG. This effect can only occur once every <span style={{ color: '#ddd' }}>10s</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'Normal Attacks deal an additional 240% ATK as DMG. This effect can only occur once every 10s.',
+                <span>
+                    Normal Attacks deal an additional <span style={{ color: '#ddd' }}>240%</span> ATK as DMG. This effect can only occur once every <span style={{ color: '#ddd' }}>10s</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'Normal Attacks deal an additional 280% ATK as DMG. This effect can only occur once every 10s.',
+                <span>
+                    Normal Attacks deal an additional <span style={{ color: '#ddd' }}>280%</span> ATK as DMG. This effect can only occur once every <span style={{ color: '#ddd' }}>10s</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'Normal Attacks deal an additional 320% ATK as DMG. This effect can only occur once every 10s.',
+                <span>
+                    Normal Attacks deal an additional <span style={{ color: '#ddd' }}>320%</span> ATK as DMG. This effect can only occur once every <span style={{ color: '#ddd' }}>10s</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default Halberd

--- a/src/data/weapons/lithic-spear.tsx
+++ b/src/data/weapons/lithic-spear.tsx
@@ -1,9 +1,29 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Lithic Axiom: Unity',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.07, 0.08, 0.09, 0.1, 0.11]
+            const critRateBonusPerStack = [0.03, 0.04, 0.05, 0.06, 0.07]
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) * (1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1]),
+                'CRIT Rate': (attributes['CRIT Rate'] || 0) + (currentStacks * critRateBonusPerStack[state.weaponRefinement - 1])
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 4,
+        stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks', '4 Stacks'],
+        priority: 1
+    }
+]
 
 const LithicSpear: Weapon = {
     name: 'Lithic Spear',
@@ -76,31 +96,51 @@ const LithicSpear: Weapon = {
     refinements: [
         {
             description:
-                'For every character in the party who hails from Liyue, the character who equips this weapon gains a 7% ATK increase and a 3% CRIT Rate increase. This effect stacks up to 4 times.',
+                <span>
+                    For every character in the party who hails from Liyue, the character who equips this weapon gains a <span style={{ color: '#ddd' }}>7%</span> ATK increase 
+                    and a <span style={{ color: '#ddd' }}>3%</span> CRIT Rate increase. This effect stacks up to 4 times.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'For every character in the party who hails from Liyue, the character who equips this weapon gains a 8% ATK increase and a 4% CRIT Rate increase. This effect stacks up to 4 times.',
+            <span>
+                For every character in the party who hails from Liyue, the character who equips this weapon gains a <span style={{ color: '#ddd' }}>8%</span> ATK increase 
+                and a <span style={{ color: '#ddd' }}>4%</span> CRIT Rate increase. This effect stacks up to 4 times.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'For every character in the party who hails from Liyue, the character who equips this weapon gains a 9% ATK increase and a 5% CRIT Rate increase. This effect stacks up to 4 times.',
+            <span>
+                For every character in the party who hails from Liyue, the character who equips this weapon gains a <span style={{ color: '#ddd' }}>9%</span> ATK increase 
+                and a <span style={{ color: '#ddd' }}>5%</span> CRIT Rate increase. This effect stacks up to 4 times.
+            </span>
+            ,
             level: 3,
         },
         {
             description:
-                'For every character in the party who hails from Liyue, the character who equips this weapon gains a 10% ATK increase and a 6% CRIT Rate increase. This effect stacks up to 4 times.',
+                <span>
+                    For every character in the party who hails from Liyue, the character who equips this weapon gains a <span style={{ color: '#ddd' }}>10%</span> ATK increase 
+                    and a <span style={{ color: '#ddd' }}>6%</span> CRIT Rate increase. This effect stacks up to 4 times.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'For every character in the party who hails from Liyue, the character who equips this weapon gains a 11% ATK increase and a 7% CRIT Rate increase. This effect stacks up to 4 times.',
+                <span>
+                    For every character in the party who hails from Liyue, the character who equips this weapon gains a <span style={{ color: '#ddd' }}>11%</span> ATK increase 
+                    and a <span style={{ color: '#ddd' }}>7%</span> CRIT Rate increase. This effect stacks up to 4 times.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default LithicSpear

--- a/src/data/weapons/missive-windspear.tsx
+++ b/src/data/weapons/missive-windspear.tsx
@@ -1,9 +1,28 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'The Wind Unattained',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.12, 0.15, 0.18, 0.21, 0.24]
+            const elementalMasteryBonusPerStack = [48, 60, 72, 84, 96]
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) * (1 + attackBonusPerStack[state.weaponRefinement - 1]),
+                'Elemental Mastery': (attributes['Elemental Mastery'] || 0) + elementalMasteryBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const MissiveWindspear: Weapon = {
     name: 'Missive Windspear',
@@ -76,31 +95,51 @@ const MissiveWindspear: Weapon = {
     refinements: [
         {
             description:
-                'Within 10s after an Elemental Reaction is triggered, ATK is increased by 12% and Elemental Mastery is increased by 48.',
+                <span>
+                    Within <span style={{ color: '#ddd' }}>10s</span> after an Elemental Reaction is triggered, 
+                    ATK is increased by <span style={{ color: '#ddd' }}>12%</span> and Elemental Mastery is increased by <span style={{ color: '#ddd' }}>48</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Within 10s after an Elemental Reaction is triggered, ATK is increased by 15% and Elemental Mastery is increased by 60.',
+            <span>
+                Within <span style={{ color: '#ddd' }}>10s</span> after an Elemental Reaction is triggered, 
+                ATK is increased by <span style={{ color: '#ddd' }}>15%</span> and Elemental Mastery is increased by <span style={{ color: '#ddd' }}>60</span>.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'Within 10s after an Elemental Reaction is triggered, ATK is increased by 18% and Elemental Mastery is increased by 72.',
+                <span>
+                    Within <span style={{ color: '#ddd' }}>10s</span> after an Elemental Reaction is triggered, 
+                    ATK is increased by <span style={{ color: '#ddd' }}>18%</span> and Elemental Mastery is increased by <span style={{ color: '#ddd' }}>72</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'Within 10s after an Elemental Reaction is triggered, ATK is increased by 21% and Elemental Mastery is increased by 84.',
+                <span>
+                    Within <span style={{ color: '#ddd' }}>10s</span> after an Elemental Reaction is triggered, 
+                    ATK is increased by <span style={{ color: '#ddd' }}>21%</span> and Elemental Mastery is increased by <span style={{ color: '#ddd' }}>84</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'Within 10s after an Elemental Reaction is triggered, ATK is increased by 24% and Elemental Mastery is increased by 96.',
+                <span>
+                    Within <span style={{ color: '#ddd' }}>10s</span> after an Elemental Reaction is triggered, 
+                    ATK is increased by <span style={{ color: '#ddd' }}>24%</span> and Elemental Mastery is increased by <span style={{ color: '#ddd' }}>96</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default MissiveWindspear

--- a/src/data/weapons/primordial-jade-winged-spear.tsx
+++ b/src/data/weapons/primordial-jade-winged-spear.tsx
@@ -1,9 +1,35 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Eagle Spear of Justice',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.032, 0.039, 0.046, 0.053, 0.06]
+            const bonusDamage = [0.12, 0.15, 0.18, 0.21, 0.24]
+
+            let extraDMG = 0
+
+            if(currentStacks === 7) {
+                extraDMG = bonusDamage[state.weaponRefinement - 1]
+            }
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) * (1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1]),
+                'All DMG Bonus': (attributes['All DMG Bonus'] || 0) + extraDMG
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 7,
+        stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks', '4 Stacks', '5 Stacks', '6 Stacks', '7 Stacks'],
+        priority: 1
+    }
+]
 
 const PrimordialJadeWingedspear: Weapon = {
     name: 'Primordial Jade Winged-Spear',
@@ -76,31 +102,56 @@ const PrimordialJadeWingedspear: Weapon = {
     refinements: [
         {
             description:
-                'On hit, increases ATK by 3.2% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 12%.',
+                <span>
+                    On hit, increases ATK by <span style={{ color: '#ddd' }}>3.2%</span> for <span style={{ color: '#ddd' }}>6s</span>. Max 7 stacks. 
+                    This effect can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While in possession of the maximum possible stacks, DMG dealt is increased by <span style={{ color: '#ddd' }}>12%</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'On hit, increases ATK by 3.9% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 15%.',
+                <span>
+                    On hit, increases ATK by <span style={{ color: '#ddd' }}>3.9%</span> for <span style={{ color: '#ddd' }}>6s</span>. Max 7 stacks. 
+                    This effect can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While in possession of the maximum possible stacks, DMG dealt is increased by <span style={{ color: '#ddd' }}>15%</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'On hit, increases ATK by 4.6% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 18%.',
+                <span>
+                    On hit, increases ATK by <span style={{ color: '#ddd' }}>4.6%</span> for <span style={{ color: '#ddd' }}>6s</span>. Max 7 stacks. 
+                    This effect can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While in possession of the maximum possible stacks, DMG dealt is increased by <span style={{ color: '#ddd' }}>18%</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'On hit, increases ATK by 5.3% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 21%.',
+                <span>
+                    On hit, increases ATK by <span style={{ color: '#ddd' }}>5.3%</span> for <span style={{ color: '#ddd' }}>6s</span>. Max 7 stacks. 
+                    This effect can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While in possession of the maximum possible stacks, DMG dealt is increased by <span style={{ color: '#ddd' }}>21%</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'On hit, increases ATK by 6% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 24%.',
+                <span>
+                    On hit, increases ATK by <span style={{ color: '#ddd' }}>6%</span> for <span style={{ color: '#ddd' }}>6s</span>. Max 7 stacks. 
+                    This effect can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While in possession of the maximum possible stacks, DMG dealt is increased by <span style={{ color: '#ddd' }}>24%</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default PrimordialJadeWingedspear

--- a/src/data/weapons/prospectors-drill.tsx
+++ b/src/data/weapons/prospectors-drill.tsx
@@ -103,7 +103,7 @@ const ProspectorsDrill: Weapon = {
         {
             description:
                 <span>
-                When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+                When the wielder is healed or heals others, they will gain a Unity&apos;s Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
                 When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
                 For each Symbol consumed, gain <span style={{ color: '#ddd' }}>3%</span> ATK and <span style={{ color: '#ddd' }}>7%</span> All Elemental DMG Bonus. 
                 The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
@@ -113,7 +113,7 @@ const ProspectorsDrill: Weapon = {
         {
             description:
             <span>
-            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When the wielder is healed or heals others, they will gain a Unity&apos;s Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
             When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
             For each Symbol consumed, gain <span style={{ color: '#ddd' }}>4%</span> ATK and <span style={{ color: '#ddd' }}>8.5%</span> All Elemental DMG Bonus. 
             The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
@@ -123,7 +123,7 @@ const ProspectorsDrill: Weapon = {
         {
             description:
             <span>
-            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When the wielder is healed or heals others, they will gain a Unity&apos;s Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
             When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
             For each Symbol consumed, gain <span style={{ color: '#ddd' }}>5%</span> ATK and <span style={{ color: '#ddd' }}>10%</span> All Elemental DMG Bonus. 
             The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
@@ -133,7 +133,7 @@ const ProspectorsDrill: Weapon = {
         {
             description:
             <span>
-            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When the wielder is healed or heals others, they will gain a Unity&apos;s Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
             When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
             For each Symbol consumed, gain <span style={{ color: '#ddd' }}>6%</span> ATK and <span style={{ color: '#ddd' }}>11.5%</span> All Elemental DMG Bonus. 
             The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
@@ -143,7 +143,7 @@ const ProspectorsDrill: Weapon = {
         {
             description:
             <span>
-            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When the wielder is healed or heals others, they will gain a Unity&apos;s Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
             When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
             For each Symbol consumed, gain <span style={{ color: '#ddd' }}>7%</span> ATK and <span style={{ color: '#ddd' }}>13%</span> All Elemental DMG Bonus. 
             The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.

--- a/src/data/weapons/prospectors-drill.tsx
+++ b/src/data/weapons/prospectors-drill.tsx
@@ -1,9 +1,35 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: "Masons' Ditty",
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const attackBonusPerStack = [0.03, 0.04, 0.05, 0.06, 0.07]
+            const elementalDamageBonusPerStack = [0.07, 0.085, 0.1, 0.115, 0.13]
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) * (1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1]),
+                'Pyro DMG Bonus': (attributes['Pyro DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Cryo DMG Bonus': (attributes['Cryo DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Hydro DMG Bonus': (attributes['Hydro DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Electro DMG Bonus': (attributes['Electro DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Anemo DMG Bonus': (attributes['Anemo DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Geo DMG Bonus': (attributes['Geo DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1]),
+                'Dendro DMG Bonus': (attributes['Dendro DMG Bonus'] || 0) + (currentStacks * elementalDamageBonusPerStack[state.weaponRefinement - 1])
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 3,
+        stackOptions: ['Off', '1 Symbol', '2 Symbols', '3 Symbols'],
+        priority: 1
+    }
+]
 
 const ProspectorsDrill: Weapon = {
     name: "Prospector's Drill",
@@ -76,31 +102,56 @@ const ProspectorsDrill: Weapon = {
     refinements: [
         {
             description:
-                "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 3% ATK and 7% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
+                <span>
+                When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+                When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
+                For each Symbol consumed, gain <span style={{ color: '#ddd' }}>3%</span> ATK and <span style={{ color: '#ddd' }}>7%</span> All Elemental DMG Bonus. 
+                The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
+                </span>,
             level: 1,
         },
         {
             description:
-                "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 4% ATK and 8.5% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
+            <span>
+            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
+            For each Symbol consumed, gain <span style={{ color: '#ddd' }}>4%</span> ATK and <span style={{ color: '#ddd' }}>8.5%</span> All Elemental DMG Bonus. 
+            The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
+            </span>,
             level: 2,
         },
         {
             description:
-                "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 5% ATK and 10% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
+            <span>
+            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
+            For each Symbol consumed, gain <span style={{ color: '#ddd' }}>5%</span> ATK and <span style={{ color: '#ddd' }}>10%</span> All Elemental DMG Bonus. 
+            The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
+            </span>,
             level: 3,
         },
         {
             description:
-                "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 6% ATK and 11.5% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
+            <span>
+            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
+            For each Symbol consumed, gain <span style={{ color: '#ddd' }}>6%</span> ATK and <span style={{ color: '#ddd' }}>11.5%</span> All Elemental DMG Bonus. 
+            The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
+            </span>,
             level: 4,
         },
         {
             description:
-                "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 7% ATK and 13% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
+            <span>
+            When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts <span style={{ color: '#ddd' }}>30s</span>, up to a maximum of 3 Symbols. 
+            When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for <span style={{ color: '#ddd' }}>10s</span>. 
+            For each Symbol consumed, gain <span style={{ color: '#ddd' }}>7%</span> ATK and <span style={{ color: '#ddd' }}>13%</span> All Elemental DMG Bonus. 
+            The Struggle effect can be triggered once every <span style={{ color: '#ddd' }}>15s</span>, and Symbols can be gained even when the character is not on the field.
+            </span>,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default ProspectorsDrill

--- a/src/data/weapons/royal-spear.tsx
+++ b/src/data/weapons/royal-spear.tsx
@@ -1,9 +1,27 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Focus',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const critRateBonusPerStack = [0.08, 0.1, 0.12, 0.14, 0.16] 
+
+            const newAttributes = {
+                ...attributes,
+                'CRIT Rate': (attributes['CRIT Rate'] || 0) + (currentStacks * critRateBonusPerStack[state.weaponRefinement - 1])
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 5,
+        stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks', '4 Stacks', '5 Stacks'],
+        priority: 1
+    }
+]
 
 const RoyalSpear: Weapon = {
     name: 'Royal Spear',
@@ -76,31 +94,46 @@ const RoyalSpear: Weapon = {
     refinements: [
         {
             description:
-                'Upon damaging an opponent, increases CRIT Rate by 8%. Max 5 stacks. A CRIT Hit removes all stacks.',
+                <span>
+                    Upon damaging an opponent, increases CRIT Rate by <span style={{ color: '#ddd' }}>8%</span>. Max 5 stacks. A CRIT Hit removes all stacks.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Upon damaging an opponent, increases CRIT Rate by 10%. Max 5 stacks. A CRIT Hit removes all stacks.',
+                <span>
+                    Upon damaging an opponent, increases CRIT Rate by <span style={{ color: '#ddd' }}>10%</span>. Max 5 stacks. A CRIT Hit removes all stacks.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'Upon damaging an opponent, increases CRIT Rate by 12%. Max 5 stacks. A CRIT Hit removes all stacks.',
+                <span>
+                    Upon damaging an opponent, increases CRIT Rate by <span style={{ color: '#ddd' }}>12%</span>. Max 5 stacks. A CRIT Hit removes all stacks.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'Upon damaging an opponent, increases CRIT Rate by 14%. Max 5 stacks. A CRIT Hit removes all stacks.',
+                <span>
+                    Upon damaging an opponent, increases CRIT Rate by <span style={{ color: '#ddd' }}>14%</span>. Max 5 stacks. A CRIT Hit removes all stacks.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'Upon damaging an opponent, increases CRIT Rate by 16%. Max 5 stacks. A CRIT Hit removes all stacks.',
+                <span>
+                    Upon damaging an opponent, increases CRIT Rate by <span style={{ color: '#ddd' }}>16%</span>. Max 5 stacks. A CRIT Hit removes all stacks.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default RoyalSpear

--- a/src/data/weapons/skyward-spine.tsx
+++ b/src/data/weapons/skyward-spine.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Black Wing',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const critRateBonusPerStack = [0.08, 0.1, 0.12, 0.14, 0.16]
+
+            const newAttributes = {
+                ...attributes,
+                'CRIT Rate': (attributes['CRIT Rate'] || 0) + critRateBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const SkywardSpine: Weapon = {
     name: 'Skyward Spine',
@@ -76,31 +93,61 @@ const SkywardSpine: Weapon = {
     refinements: [
         {
             description:
-                'Increases CRIT Rate by 8% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 40% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.',
+                <span>
+                    Increases CRIT Rate by <span style={{ color: '#ddd' }}>8%</span> and increases Normal ATK SPD by <span style={{ color: '#ddd' }}>12%</span>. 
+                    Additionally, Normal and Charged Attacks hits on opponents have a <span style={{ color: '#ddd' }}>50%</span> chance 
+                    to trigger a vacuum blade that deals <span style={{ color: '#ddd' }}>40%</span> of ATK as DMG in a small AoE. 
+                    This effect can occur no more than once every <span style={{ color: '#ddd' }}>2s</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Increases CRIT Rate by 10% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 55% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.',
+            <span>
+                Increases CRIT Rate by <span style={{ color: '#ddd' }}>10%</span> and increases Normal ATK SPD by <span style={{ color: '#ddd' }}>12%</span>. 
+                Additionally, Normal and Charged Attacks hits on opponents have a <span style={{ color: '#ddd' }}>50%</span> chance 
+                to trigger a vacuum blade that deals <span style={{ color: '#ddd' }}>55%</span> of ATK as DMG in a small AoE. 
+                This effect can occur no more than once every <span style={{ color: '#ddd' }}>2s</span>.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'Increases CRIT Rate by 12% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 70% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.',
+            <span>
+                Increases CRIT Rate by <span style={{ color: '#ddd' }}>12%</span> and increases Normal ATK SPD by <span style={{ color: '#ddd' }}>12%</span>. 
+                Additionally, Normal and Charged Attacks hits on opponents have a <span style={{ color: '#ddd' }}>50%</span> chance 
+                to trigger a vacuum blade that deals <span style={{ color: '#ddd' }}>70%</span> of ATK as DMG in a small AoE. 
+                This effect can occur no more than once every <span style={{ color: '#ddd' }}>2s</span>.
+            </span>
+            ,
             level: 3,
         },
         {
             description:
-                'Increases CRIT Rate by 14% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 85% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.',
+            <span>
+                Increases CRIT Rate by <span style={{ color: '#ddd' }}>14%</span> and increases Normal ATK SPD by <span style={{ color: '#ddd' }}>12%</span>. 
+                Additionally, Normal and Charged Attacks hits on opponents have a <span style={{ color: '#ddd' }}>50%</span> chance 
+                to trigger a vacuum blade that deals <span style={{ color: '#ddd' }}>85%</span> of ATK as DMG in a small AoE. 
+                This effect can occur no more than once every <span style={{ color: '#ddd' }}>2s</span>.
+            </span>
+            ,
             level: 4,
         },
         {
             description:
-                'Increases CRIT Rate by 16% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 100% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.',
+            <span>
+                Increases CRIT Rate by <span style={{ color: '#ddd' }}>16%</span> and increases Normal ATK SPD by <span style={{ color: '#ddd' }}>12%</span>. 
+                Additionally, Normal and Charged Attacks hits on opponents have a <span style={{ color: '#ddd' }}>50%</span> chance 
+                to trigger a vacuum blade that deals <span style={{ color: '#ddd' }}>100%</span> of ATK as DMG in a small AoE. 
+                This effect can occur no more than once every <span style={{ color: '#ddd' }}>2s</span>.
+            </span>
+            ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default SkywardSpine

--- a/src/data/weapons/staff-of-homa.tsx
+++ b/src/data/weapons/staff-of-homa.tsx
@@ -14,7 +14,7 @@ const weaponBonuses: Bonus[] = [
 
             let attackBonus = 0
             let newHealth =
-                (attributes['HP'] || 0) + hpBonus[state.weaponRefinement - 1]
+                (attributes['HP'] || 0) * (1 + hpBonus[state.weaponRefinement - 1])
 
             if (currentStacks === 1) {
                 attackBonus = attackBonusPerStack[state.weaponRefinement - 1]

--- a/src/data/weapons/staff-of-the-scarlet-sands.tsx
+++ b/src/data/weapons/staff-of-the-scarlet-sands.tsx
@@ -1,9 +1,31 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: "Heat Haze at Horizon's End",
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const elementalMasterytoAttackScaling = [0.52, 0.65, 0.78, 0.91, 1.04]
+            const elementalMasterytoAttackBonusPerStack = [0.28, 0.35, 0.42, 0.49, 0.56]
+
+            let newAttack = (attributes['Elemental Mastery'] || 0) * (elementalMasterytoAttackScaling[state.weaponRefinement - 1])
+            let stackNewAttack = (attributes['Elemental Mastery'] || 0) * (currentStacks * elementalMasterytoAttackBonusPerStack[state.weaponRefinement - 1])
+
+            const newAttributes = {
+                ...attributes,
+                ATK: (attributes['ATK'] || 0) + newAttack + stackNewAttack
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 3,
+        stackOptions: ['Off', '1 Stack', '2 Stacks', '3 Stacks'],
+        priority: 2
+    }
+]
 
 const StaffOfTheScarletSands: Weapon = {
     name: 'Staff of the Scarlet Sands',
@@ -76,31 +98,56 @@ const StaffOfTheScarletSands: Weapon = {
     refinements: [
         {
             description:
-                'The equipping character gains 52% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 28% of their Elemental Mastery as bonus ATK. Max 3 stacks.',
+                <span>
+                    The equipping character gains <span style={{ color: '#ddd' }}>52%</span> of their Elemental Mastery as bonus ATK. 
+                    When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for <span style={{ color: '#ddd' }}>10s</span>: 
+                    The equipping character will gain <span style={{ color: '#ddd' }}>28%</span> of their Elemental Mastery as bonus ATK. Max 3 stacks.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'The equipping character gains 65% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 35% of their Elemental Mastery as bonus ATK. Max 3 stacks.',
+            <span>
+                The equipping character gains <span style={{ color: '#ddd' }}>65%</span> of their Elemental Mastery as bonus ATK. 
+                When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for <span style={{ color: '#ddd' }}>10s</span>: 
+                The equipping character will gain <span style={{ color: '#ddd' }}>35%</span> of their Elemental Mastery as bonus ATK. Max 3 stacks.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'The equipping character gains 78% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 42% of their Elemental Mastery as bonus ATK. Max 3 stacks.',
+            <span>
+                The equipping character gains <span style={{ color: '#ddd' }}>78%</span> of their Elemental Mastery as bonus ATK. 
+                When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for <span style={{ color: '#ddd' }}>10s</span>: 
+                The equipping character will gain <span style={{ color: '#ddd' }}>42%</span> of their Elemental Mastery as bonus ATK. Max 3 stacks.
+            </span>
+            ,
             level: 3,
         },
         {
             description:
-                'The equipping character gains 91% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 49% of their Elemental Mastery as bonus ATK. Max 3 stacks.',
+            <span>
+                The equipping character gains <span style={{ color: '#ddd' }}>91%</span> of their Elemental Mastery as bonus ATK. 
+                When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for <span style={{ color: '#ddd' }}>10s</span>: 
+                The equipping character will gain <span style={{ color: '#ddd' }}>49%</span> of their Elemental Mastery as bonus ATK. Max 3 stacks.
+            </span>
+            ,
             level: 4,
         },
         {
             description:
-                'The equipping character gains 104% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 56% of their Elemental Mastery as bonus ATK. Max 3 stacks.',
+            <span>
+                The equipping character gains <span style={{ color: '#ddd' }}>104%</span> of their Elemental Mastery as bonus ATK. 
+                When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for <span style={{ color: '#ddd' }}>10s</span>: 
+                The equipping character will gain <span style={{ color: '#ddd' }}>56%</span> of their Elemental Mastery as bonus ATK. Max 3 stacks.
+            </span>
+            ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default StaffOfTheScarletSands

--- a/src/data/weapons/the-catch.tsx
+++ b/src/data/weapons/the-catch.tsx
@@ -1,9 +1,28 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Shanty',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const elementalBurstDMGBonusPerStack = [0.16, 0.2, 0.24, 0.28, 0.32]
+            const elementalBurstCritRateBonusPerStack = [0.06, 0.075, 0.09, 0.105, 0.12]
+
+            const newAttributes = {
+                ...attributes,
+                'Elemental Burst DMG Bonus': (attributes['Elemental Burst DMG Bonus'] || 0) + elementalBurstDMGBonusPerStack[state.weaponRefinement - 1],
+                'Elemental Burst CRIT Rate': (attributes['Elemental Burst CRIT Rate'] || 0) + elementalBurstCritRateBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const TheCatch: Weapon = {
     name: '"The Catch"',
@@ -76,31 +95,46 @@ const TheCatch: Weapon = {
     refinements: [
         {
             description:
-                'Increases Elemental Burst DMG by 16% and Elemental Burst CRIT Rate by 6%.',
+                <span>
+                    Increases Elemental Burst DMG by <span style={{ color: '#ddd' }}>16%</span> and Elemental Burst CRIT Rate by <span style={{ color: '#ddd' }}>6%</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Increases Elemental Burst DMG by 20% and Elemental Burst CRIT Rate by 7.5%.',
+                <span>
+                    Increases Elemental Burst DMG by <span style={{ color: '#ddd' }}>20%</span> and Elemental Burst CRIT Rate by <span style={{ color: '#ddd' }}>7.5%</span>.
+                </span>
+                ,
             level: 2,
         },
         {
             description:
-                'Increases Elemental Burst DMG by 24% and Elemental Burst CRIT Rate by 9%.',
+                <span>
+                    Increases Elemental Burst DMG by <span style={{ color: '#ddd' }}>24%</span> and Elemental Burst CRIT Rate by <span style={{ color: '#ddd' }}>9%</span>.
+                </span>
+                ,
             level: 3,
         },
         {
             description:
-                'Increases Elemental Burst DMG by 28% and Elemental Burst CRIT Rate by 10.5%.',
+                <span>
+                    Increases Elemental Burst DMG by <span style={{ color: '#ddd' }}>28%</span> and Elemental Burst CRIT Rate by <span style={{ color: '#ddd' }}>10.5%</span>.
+                </span>
+                ,
             level: 4,
         },
         {
             description:
-                'Increases Elemental Burst DMG by 32% and Elemental Burst CRIT Rate by 12%.',
+                <span>
+                    Increases Elemental Burst DMG by <span style={{ color: '#ddd' }}>32%</span> and Elemental Burst CRIT Rate by <span style={{ color: '#ddd' }}>12%</span>.
+                </span>
+                ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default TheCatch

--- a/src/data/weapons/vortex-vanquisher.tsx
+++ b/src/data/weapons/vortex-vanquisher.tsx
@@ -1,9 +1,37 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Golden Majesty',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const shieldStrengthBonusPerStack = [0.2, 0.25, 0.3, 0.35, 0.4]
+            const attackBonusPerStack = [0.04, 0.05, 0.06, 0.07, 0.08]
+
+            let attackBonus = 0
+
+            if(currentStacks <= 5) {
+                attackBonus = 1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1] * 2
+            } else if (currentStacks > 5) {
+                attackBonus = 1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1]
+            }
+
+            const newAttributes = {
+                ...attributes,
+                'Shield Strength': (attributes['Shield Strength'] || 0) + shieldStrengthBonusPerStack[state.weaponRefinement - 1],
+                ATK: (attributes['ATK'] || 0) * attackBonus
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 10,
+        stackOptions: ['Off', 'Shielded 1 Stack', 'Shielded 2 Stacks', 'Shielded 3 Stacks', 'Shielded 4 Stacks', 'Shielded 5 Stacks', 'Unshielded 1 Stack', 'Unshielded 2 Stacks', 'Unshielded 3 Stacks', 'Unshielded 4 Stacks', 'Unshielded 5 Stacks'],
+        priority: 1
+    }
+]
 
 const VortexVanquisher: Weapon = {
     name: 'Vortex Vanquisher',
@@ -76,31 +104,61 @@ const VortexVanquisher: Weapon = {
     refinements: [
         {
             description:
-                'Increases Shield Strength by 20%. Scoring hits on opponents increases ATK by 4% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.',
+                <span>
+                    Increases Shield Strength by <span style={{ color: '#ddd' }}>20%</span>. Scoring hits on opponents increases ATK by <span style={{ color: '#ddd' }}>4%</span> {' '}
+                    for <span style={{ color: '#ddd' }}>8s</span>. Max 5 stacks. 
+                    Can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                    While protected by a shield, this ATK increase effect is increased by <span style={{ color: '#ddd' }}>100%</span>.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                'Increases Shield Strength by 25%. Scoring hits on opponents increases ATK by 5% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.',
+            <span>
+                Increases Shield Strength by <span style={{ color: '#ddd' }}>25%</span>. Scoring hits on opponents increases ATK by <span style={{ color: '#ddd' }}>5%</span> {' '}
+                for <span style={{ color: '#ddd' }}>8s</span>. Max 5 stacks. 
+                Can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                While protected by a shield, this ATK increase effect is increased by <span style={{ color: '#ddd' }}>100%</span>.
+            </span>
+            ,
             level: 2,
         },
         {
             description:
-                'Increases Shield Strength by 30%. Scoring hits on opponents increases ATK by 6% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.',
+            <span>
+                Increases Shield Strength by <span style={{ color: '#ddd' }}>30%</span>. Scoring hits on opponents increases ATK by <span style={{ color: '#ddd' }}>6%</span> {' '}
+                for <span style={{ color: '#ddd' }}>8s</span>. Max 5 stacks. 
+                Can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                While protected by a shield, this ATK increase effect is increased by <span style={{ color: '#ddd' }}>100%</span>.
+            </span>
+            ,
             level: 3,
         },
         {
             description:
-                'Increases Shield Strength by 35%. Scoring hits on opponents increases ATK by 7% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.',
+            <span>
+                Increases Shield Strength by <span style={{ color: '#ddd' }}>35%</span>. Scoring hits on opponents increases ATK by <span style={{ color: '#ddd' }}>7%</span> {' '}
+                for <span style={{ color: '#ddd' }}>8s</span>. Max 5 stacks. 
+                Can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                While protected by a shield, this ATK increase effect is increased by <span style={{ color: '#ddd' }}>100%</span>.
+            </span>
+            ,
             level: 4,
         },
         {
             description:
-                'Increases Shield Strength by 40%. Scoring hits on opponents increases ATK by 8% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.',
+            <span>
+                Increases Shield Strength by <span style={{ color: '#ddd' }}>40%</span>. Scoring hits on opponents increases ATK by <span style={{ color: '#ddd' }}>8%</span> {' '}
+                for <span style={{ color: '#ddd' }}>8s</span>. Max 5 stacks. 
+                Can only occur once every <span style={{ color: '#ddd' }}>0.3s</span>. 
+                While protected by a shield, this ATK increase effect is increased by <span style={{ color: '#ddd' }}>100%</span>.
+            </span>
+            ,
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default VortexVanquisher

--- a/src/data/weapons/vortex-vanquisher.tsx
+++ b/src/data/weapons/vortex-vanquisher.tsx
@@ -17,7 +17,7 @@ const weaponBonuses: Bonus[] = [
             if(currentStacks <= 5) {
                 attackBonus = 1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1] * 2
             } else if (currentStacks > 5) {
-                attackBonus = 1 + currentStacks * attackBonusPerStack[state.weaponRefinement - 1]
+                attackBonus = 1 + (currentStacks - 5) * attackBonusPerStack[state.weaponRefinement - 1]
             }
 
             const newAttributes = {

--- a/src/data/weapons/wavebreakers-fin.tsx
+++ b/src/data/weapons/wavebreakers-fin.tsx
@@ -1,9 +1,28 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Watatsumi Wavewalker',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const elementalBurstBonusPerStack = [0.0012, 0.0015, 0.0018, 0.0021, 0.0024]
+            const maxBonusPerStack = [0.4, 0.5, 0.6, 0.7, 0.8]
+
+            const newAttributes = {
+                ...attributes,
+                'Elemental Burst DMG Bonus': (attributes['Elemental Burst DMG Bonus'] || 0) + Math.min(elementalBurstBonusPerStack[state.weaponRefinement - 1] * ((currentStacks * 10 + 30) * 4), maxBonusPerStack[state.weaponRefinement - 1])
+            }
+            return { attributes: newAttributes }
+        },
+        maxStacks: 6,
+        stackOptions: ['Off', '40 Cost', '50 Cost', '60 Cost', '70 Cost', '80 Cost', '90 Cost'],
+        priority: 1
+    }
+]
 
 const WavebreakersFin: Weapon = {
     name: "Wavebreaker's Fin",
@@ -76,31 +95,56 @@ const WavebreakersFin: Weapon = {
     refinements: [
         {
             description:
-                "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.12%. A maximum of 40% increased Elemental Burst DMG can be achieved this way.",
+                <span>
+                    For every point of the entire party's combined maximum Energy capacity, 
+                    the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.12%</span>. 
+                    A maximum of <span style={{ color: '#ddd' }}>40%</span> increased Elemental Burst DMG can be achieved this way.
+                </span>
+                ,
             level: 1,
         },
         {
             description:
-                "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.15%. A maximum of 50% increased Elemental Burst DMG can be achieved this way.",
-            level: 2,
+                <span>
+                    For every point of the entire party's combined maximum Energy capacity, 
+                    the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.15%</span>. 
+                    A maximum of <span style={{ color: '#ddd' }}>50%</span> increased Elemental Burst DMG can be achieved this way.
+                </span>
+                ,
+                level: 2,
         },
         {
             description:
-                "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.18%. A maximum of 60% increased Elemental Burst DMG can be achieved this way.",
-            level: 3,
+                <span>
+                    For every point of the entire party's combined maximum Energy capacity, 
+                    the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.18%</span>. 
+                    A maximum of <span style={{ color: '#ddd' }}>60%</span> increased Elemental Burst DMG can be achieved this way.
+                </span>
+                ,
+                level: 3,
         },
         {
             description:
-                "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.21%. A maximum of 70% increased Elemental Burst DMG can be achieved this way.",
+            <span>
+                For every point of the entire party's combined maximum Energy capacity, 
+                the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.21%</span>. 
+                A maximum of <span style={{ color: '#ddd' }}>70%</span> increased Elemental Burst DMG can be achieved this way.
+            </span>
+            ,
             level: 4,
         },
         {
             description:
-                "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.24%. A maximum of 80% increased Elemental Burst DMG can be achieved this way.",
-            level: 5,
+                <span>
+                    For every point of the entire party's combined maximum Energy capacity, 
+                    the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.24%</span>. 
+                    A maximum of <span style={{ color: '#ddd' }}>80%</span> increased Elemental Burst DMG can be achieved this way.
+                </span>
+                ,
+                level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default WavebreakersFin

--- a/src/data/weapons/wavebreakers-fin.tsx
+++ b/src/data/weapons/wavebreakers-fin.tsx
@@ -96,7 +96,7 @@ const WavebreakersFin: Weapon = {
         {
             description:
                 <span>
-                    For every point of the entire party's combined maximum Energy capacity, 
+                    For every point of the entire party&apos;s combined maximum Energy capacity, 
                     the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.12%</span>. 
                     A maximum of <span style={{ color: '#ddd' }}>40%</span> increased Elemental Burst DMG can be achieved this way.
                 </span>
@@ -106,7 +106,7 @@ const WavebreakersFin: Weapon = {
         {
             description:
                 <span>
-                    For every point of the entire party's combined maximum Energy capacity, 
+                    For every point of the entire party&apos;s combined maximum Energy capacity, 
                     the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.15%</span>. 
                     A maximum of <span style={{ color: '#ddd' }}>50%</span> increased Elemental Burst DMG can be achieved this way.
                 </span>
@@ -116,7 +116,7 @@ const WavebreakersFin: Weapon = {
         {
             description:
                 <span>
-                    For every point of the entire party's combined maximum Energy capacity, 
+                    For every point of the entire party&apos;s combined maximum Energy capacity, 
                     the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.18%</span>. 
                     A maximum of <span style={{ color: '#ddd' }}>60%</span> increased Elemental Burst DMG can be achieved this way.
                 </span>
@@ -126,7 +126,7 @@ const WavebreakersFin: Weapon = {
         {
             description:
             <span>
-                For every point of the entire party's combined maximum Energy capacity, 
+                For every point of the entire party&apos;s combined maximum Energy capacity, 
                 the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.21%</span>. 
                 A maximum of <span style={{ color: '#ddd' }}>70%</span> increased Elemental Burst DMG can be achieved this way.
             </span>
@@ -136,7 +136,7 @@ const WavebreakersFin: Weapon = {
         {
             description:
                 <span>
-                    For every point of the entire party's combined maximum Energy capacity, 
+                    For every point of the entire party&apos;s combined maximum Energy capacity, 
                     the Elemental Burst DMG of the character equipping this weapon is increased by <span style={{ color: '#ddd' }}>0.24%</span>. 
                     A maximum of <span style={{ color: '#ddd' }}>80%</span> increased Elemental Burst DMG can be achieved this way.
                 </span>

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -86,7 +86,8 @@
                 "description": "Increases Elemental Burst DMG by 32% and Elemental Burst CRIT Rate by 12%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "\"Ultimate Overlord's Mega Magic Sword\"": {
         "name": "\"Ultimate Overlord's Mega Magic Sword\"",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -12354,7 +12354,8 @@
                 "description": "The equipping character gains 104% of their Elemental Mastery as bonus ATK. When an Elemental Skill hits opponents, the Dream of the Scarlet Sands effect will be gained for 10s: The equipping character will gain 56% of their Elemental Mastery as bonus ATK. Max 3 stacks.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Summit Shaper": {
         "name": "Summit Shaper",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -11641,7 +11641,8 @@
                 "description": "Increases CRIT Rate by 16% and increases Normal ATK SPD by 12%. Additionally, Normal and Charged Attacks hits on opponents have a 50% chance to trigger a vacuum blade that deals 100% of ATK as DMG in a small AoE. This effect can occur no more than once every 2s.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Slingshot": {
         "name": "Slingshot",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -3328,7 +3328,8 @@
                 "description": "ATK increased by 56% of Energy Recharge over the base 100%. You can gain a maximum bonus of 120% ATK. Gain 50% Energy Recharge for 12s after using an Elemental Burst.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Everlasting Moonglow": {
         "name": "Everlasting Moonglow",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -8614,7 +8614,8 @@
                 "description": "When the wielder is healed or heals others, they will gain a Unity's Symbol that lasts 30s, up to a maximum of 3 Symbols. When using their Elemental Skill or Burst, all Symbols will be consumed and the Struggle effect will be granted for 10s. For each Symbol consumed, gain 7% ATK and 13% All Elemental DMG Bonus. The Struggle effect can be triggered once every 15s, and Symbols can be gained even when the character is not on the field.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Prototype Amber": {
         "name": "Prototype Amber",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -14369,7 +14369,8 @@
                 "description": "Increases Shield Strength by 40%. Scoring hits on opponents increases ATK by 8% for 8s. Max 5 stacks. Can only occur once every 0.3s. While protected by a shield, this ATK increase effect is increased by 100%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Wandering Evenstar": {
         "name": "Wandering Evenstar",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -1017,7 +1017,8 @@
                 "description": "When there are at least 3 different Elemental Types in your party, Elemental Mastery will be increased by 240.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Beacon of the Reed Sea": {
         "name": "Beacon of the Reed Sea",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -1862,7 +1862,8 @@
                 "description": "Gain 24% All Elemental DMG Bonus. Obtain Consummation for 20s after using an Elemental Skill, causing ATK to increase by 6.4% per second. This ATK increase has a maximum of 6 stacks. When the character equipped with this weapon is not on the field, Consummation's ATK increase is doubled.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Cashflow Supervision": {
         "name": "Cashflow Supervision",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -3857,7 +3857,8 @@
                 "description": "CRIT Hits have a 100% chance to generate a small amount of Elemental Particles, which will regenerate 6 Energy for the character. Can only occur once every 6s.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Favonius Sword": {
         "name": "Favonius Sword",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -10038,7 +10038,8 @@
                 "description": "Upon damaging an opponent, increases CRIT Rate by 16%. Max 5 stacks. A CRIT Hit removes all stacks.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Rust": {
         "name": "Rust",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -5102,7 +5102,8 @@
                 "description": "Normal Attacks deal an additional 320% ATK as DMG. This effect can only occur once every 10s.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Hamayumi": {
         "name": "Hamayumi",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -6681,7 +6681,8 @@
                 "description": "For every character in the party who hails from Liyue, the character who equips this weapon gains a 11% ATK increase and a 7% CRIT Rate increase. This effect stacks up to 4 times.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Lost Prayer to the Sacred Winds": {
         "name": "Lost Prayer to the Sacred Winds",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -8533,7 +8533,8 @@
                 "description": "On hit, increases ATK by 6% for 6s. Max 7 stacks. This effect can only occur once every 0.3s. While in possession of the maximum possible stacks, DMG dealt is increased by 24%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Prospector's Drill": {
         "name": "Prospector's Drill",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -7482,7 +7482,8 @@
                 "description": "Within 10s after an Elemental Reaction is triggered, ATK is increased by 24% and Elemental Mastery is increased by 96.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Mistsplitter Reforged": {
         "name": "Mistsplitter Reforged",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -14753,7 +14753,8 @@
                 "description": "Increases Normal Attack DMG by 48%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Whiteblind": {
         "name": "Whiteblind",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -2838,7 +2838,8 @@
                 "description": "Increases DMG against opponents affected by Hydro or Pyro by 36%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Dragonspine Spear": {
         "name": "Dragonspine Spear",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -1235,7 +1235,8 @@
                 "description": "Increases DMG against slimes by 80%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Blackcliff Agate": {
         "name": "Blackcliff Agate",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -1503,7 +1503,8 @@
                 "description": "After defeating an enemy, ATK is increased by 24% for 30s. This effect has a maximum of 3 stacks, and the duration of each stack is independent of the others.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Blackcliff Slasher": {
         "name": "Blackcliff Slasher",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -14577,7 +14577,8 @@
                 "description": "For every point of the entire party's combined maximum Energy capacity, the Elemental Burst DMG of the character equipping this weapon is increased by 0.24%. A maximum of 80% increased Elemental Burst DMG can be achieved this way.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "White Iron Greatsword": {
         "name": "White Iron Greatsword",

--- a/src/data/weapons/weapons.json
+++ b/src/data/weapons/weapons.json
@@ -2571,7 +2571,8 @@
                 "description": "If there are at least 2 opponents nearby, ATK is increased by 32% and DEF is increased by 32%. If there are fewer than 2 opponents nearby, ATK is increased by 48%.",
                 "level": 5
             }
-        ]
+        ],
+        "implemented": true
     },
     "Debate Club": {
         "name": "Debate Club",

--- a/src/data/weapons/white-tassel.tsx
+++ b/src/data/weapons/white-tassel.tsx
@@ -1,9 +1,26 @@
 import { Weapon } from '@/interfaces/Weapon'
-// import { Bonus } from '@/interfaces/Character'
+import { Bonus } from '@/interfaces/Character'
 
-// const weaponBonuses: Bonus[] = [
-// TODO: Implement
-// ]
+const weaponBonuses: Bonus[] = [
+    {
+        name: 'Sharp',
+        effect: (attributes, talentLevels, currentStacks, state) => {
+            if (!currentStacks || !state || !state.weaponRefinement) {
+                return { attributes }
+            }
+
+            const normalAttackBonusPerStack = [0.24, 0.3, 0.36, 0.42, 0.48] 
+
+            const newAttributes = {
+                ...attributes,
+                'Normal Attack DMG Bonus': (attributes['Normal Attack DMG Bonus'] || 0) + normalAttackBonusPerStack[state.weaponRefinement - 1]
+            }
+            return { attributes: newAttributes }
+        },
+        enabled: false,
+        priority: 1
+    }
+]
 
 const WhiteTassel: Weapon = {
     name: 'White Tassel',
@@ -74,27 +91,47 @@ const WhiteTassel: Weapon = {
     },
     refinements: [
         {
-            description: 'Increases Normal Attack DMG by 24%.',
+            description: (
+                <span>
+                    Increases Normal Attack DMG by <span style={{ color: '#ddd' }}>24%</span>.
+                </span>
+            ),
             level: 1,
         },
         {
-            description: 'Increases Normal Attack DMG by 30%.',
+            description: (
+                <span>
+                    Increases Normal Attack DMG by <span style={{ color: '#ddd' }}>30%</span>.
+                </span>
+            ),
             level: 2,
         },
         {
-            description: 'Increases Normal Attack DMG by 36%.',
+            description: (
+                <span>
+                    Increases Normal Attack DMG by <span style={{ color: '#ddd' }}>36%</span>.
+                </span>
+            ),
             level: 3,
         },
         {
-            description: 'Increases Normal Attack DMG by 42%.',
+            description: (
+                <span>
+                    Increases Normal Attack DMG by <span style={{ color: '#ddd' }}>42%</span>.
+                </span>
+            ),
             level: 4,
         },
         {
-            description: 'Increases Normal Attack DMG by 48%.',
+            description: (
+                <span>
+                    Increases Normal Attack DMG by <span style={{ color: '#ddd' }}>48%</span>.
+                </span>
+            ),
             level: 5,
         },
     ],
-    // weaponBonuses
+    weaponBonuses
 }
 
 export default WhiteTassel


### PR DESCRIPTION
As of 12/27/2023, all polearms in the game are implemented.

Staff of Homa was also fixed. Previously, it failed to add health despite its passive due to incorrect calculations.

Weapons that require parties for their passive have placeholder solutions to them as of now.